### PR TITLE
Update dependencies to fix gradlew build

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -7,5 +7,5 @@ mod_version=0.1.0
 # Dependencies
 rf_mc_version=1.12
 rf_version=2.0.1.+
-cofh_core_version=4.3.7.+
-tf_version=2.3.7.+
+cofh_core_version=4.3.8.+
+tf_version=2.3.8.+


### PR DESCRIPTION
At the moment running 'gradlew build' on the 1.12 branch of Thermal Innovation fails because it references versions of COFH Core and Foundation that don't have the required classes. This is a simple fix.

This is fixed in the dev branch so we can wait for that to merge but I thought it would be nice for people to be able to instantly download and play with the new mod (which I am really liking BTW, provides a nice tool progression throughout the whole game from basic to resonant enchanted)

Hope this isn't too awkward/annoying.